### PR TITLE
Add a SkotOS Games page with current games, old games and fragments

### DIFF
--- a/Games.md
+++ b/Games.md
@@ -1,0 +1,51 @@
+# SkotOS Games Past and Present
+
+This is a large, but not fully comprehensive, list of SkotOS-based and Skotos-Tech-related games.
+
+Some of them have left fragments of code scattered about, while others have not.
+
+## Current SkotOS Games
+
+* [Castle Marrach](https://www.marrach.com/)
+* [The Eternal City](https://www.eternalcitygame.com/) - was this one based on SkotOS
+* [Allegory of Empires](https://allegoryofempires.com/)
+* [Multiverse; Revelations](https://home.multirev.net/)
+
+[The Gables](https://gables.chattheatre.com) is more of a stage than a game, but it's SkotOS-based and live.
+
+## Inoperative Games
+
+* [Grendel's Revenge](https://www.skotos.net/about/pr/06122002.html)
+* [Ironclaw Online,](https://www.skotos.net/about/pr/Nov28_2000.html)
+* [The Lazarus](https://www.lazarus-project.net/) [Project](https://www.skotos.net/about/pr/01032007a.html)
+* [Galactic Emperor: Succession](http://www.skotos.net/games/succession.html) - is this the same game as Hegemony? Or a smaller stage of it?
+
+I believe everything in this section saw a release and later stopped operation.
+
+You can find some history of many things here [in this article by Shannon Appelcline](https://www.skotos.net/articles/TTnT_47.shtml.html).
+
+There were also SkotOS-affiliated games that didn't seem to be based on the SkotOS engine:
+
+[two MMORPGs--both fully graphical RPGs, unlike our own offerings. They were Underlight and Meridian 59: Sacred Haven. Since then we've added another four: Gang of Four (March 22), Space Federation (June 3), Queen's Necklace (June 6), and Droidarena (August 8). We've actually got an eleventh game too, Fist of Dragonstones, which we've been offering as a beta-test since December, and haven't completed the integrations solely due to time-constraints. I expect to have it fully available next week.](https://www.skotos.net/articles/TTnT_/TTnT_139.phtml.html)
+
+## Fragments, Unreleased, Unknown
+
+There have been [various small stages](https://www.skotos.net/articles/TTnT_47.shtml.html) that were never meant to be full-sized games.
+
+Other fragmentary, unfinished or not-well-documented parts include:
+
+* [Lovecraft](http://www.lovecraftcountry.com/comic/) [Country](https://www.skotos.net/about/pr/06292005.html), which included "Arkham By Night" and a smaller stage called The Oasis; this clearly had a usable beta release and a lot of usable code
+* The Skoot On Inn was a small test stage that seems to have existed in several revisions, and seems also to have been called The Tavern and possibly The Hearth
+* Headquarters isn't a separate game, but a staff-only area that exists inside several games
+* The Mansion, a.k.a. The Gables has existed in several revisions, including the currently-live one
+* Regency - an unfinished(?) game involving Regency castles which produced a lot of in-game objects
+* Orphan Crown - this exists in in-game fragments ([mentioned here](https://www.skotos.net/articles/TTnT_/TTnT_139.phtml.html))
+* Pendragon Online - this exists in in-game fragments ([mentioned here](https://www.skotos.net/articles/TTnT_/TTnT_139.phtml.html))
+* The Devil's Cay - Laurel Stuart wrote a [series of articles](http://www.skotos.net/articles/trenches.shtml.html) about building it
+* Horizon Station - Sam Witt [wrote articles](http://www.skotos.net/articles/METASTATIC.shtml.html) about working on it
+* Qigung - Jeff Crook [wrote about working on it](http://www.skotos.net/articles/EASTWIND.shtml.html)
+* Arcana - Gareth Michael Skarka was attempting to build a horror game and [wrote about it](http://www.skotos.net/articles/SIGNALS.shtml.html)
+* Glory of the Nile - was to be a SkotOS Theatre; [(articles)](http://www.skotos.net/articles/playing.shtml.html)
+* S7 - not a game but a library from the "Skotos Seven" series of game projects
+* The Bane - ["In The Bane you might be a Sun Worshipper with uncertain loyalties..."](https://www.skotos.net/storyplayers/introX.html) - The Bane was one of the earliest SkotOS game attempts
+* The Welcome Room / The Link Zone - this was an out-of-character chat area, still to be found in some in-game fragments


### PR DESCRIPTION
I keep wanting to refer to this stuff in documentation. And given how often I find myself wondering, "wait, Regency - what is that?" or "was OrphanCrown a game?" I'm sure other people will as well.

I'd love to improve the information from here. But mostly this PR gets the page in the repo so we can fix from here.